### PR TITLE
Corrected "commented out" stylesheet link format, used for SimpLESS/LESS...

### DIFF
--- a/war/builder/modules/less/less.html
+++ b/war/builder/modules/less/less.html
@@ -4,5 +4,5 @@
 	<!-- Use SimpLESS (Win/Linux/Mac) or LESS.app (Mac) to compile your .less files
 	to style.css, and replace the 2 lines above by this one:
 
-	<link rel="stylesheet/less" href="less/style.css">
+	<link rel="stylesheet" type="text/css" href="less/style.css">
 	 -->


### PR DESCRIPTION
....app compiled .less files. Previous format would not properly link a CSS file.
